### PR TITLE
AccountDetails

### DIFF
--- a/Components/Pages/AccountDetails.razor
+++ b/Components/Pages/AccountDetails.razor
@@ -1,0 +1,91 @@
+﻿@page "/accountDetails/{Username}"
+@using RiotAccountManager.MAUI.Data.Models
+@using RiotAccountManager.MAUI.Data.Repositories
+@using RiotAccountManager.MAUI.Services.LcuService
+@inject AccountRepository Repository
+@inject ILcuService LcuService
+
+@if (account != null)
+{
+    <p><strong>Login:</strong> @account.Username</p>
+    <p><strong>Nickname:</strong> @account.Nickname</p>
+    
+    @if (!isClientRunning)
+    {
+        <p class="text-danger">League of Legends klient nie jest uruchomiony.</p>
+    }
+
+    <button class="btn btn-primary" @onclick="FetchRankedData">
+        Pobierz dane Ranked
+    </button>
+
+    @if (rankedEntry != null)
+    {
+        <hr />
+        <h4>Dane Ranked:</h4>
+        <p><strong>Queue Type:</strong> @rankedEntry.QueueType</p>
+        <p><strong>Tier:</strong> @rankedEntry.Tier</p>
+        <p><strong>Division:</strong> @rankedEntry.Division</p>
+        <p><strong>League Points:</strong> @rankedEntry.LeaguePoints</p>
+        <p><strong>Wins:</strong> @rankedEntry.Wins</p>
+        <p><strong>Losses:</strong> @rankedEntry.Losses</p>
+    }
+}
+else
+{
+    <p>Nie znaleziono konta.</p>
+}
+
+@code {
+    [Parameter]
+    public string Username { get; set; }
+
+    private Account account;
+    private RankedEntryDto rankedEntry;
+    private bool isClientRunning = false;
+    private Timer refreshTimer;
+
+    protected override async void OnInitialized()
+    {
+        account = Repository.GetAll().FirstOrDefault(a => a.Username == Username);
+
+        await CheckClientStatusAsync();
+
+        if (isClientRunning)
+        {
+            refreshTimer = new Timer(async _ =>
+            {
+                await InvokeAsync(async () =>
+                {
+                    await FetchRankedData();
+                    StateHasChanged();
+                });
+            }, null, 0, 10000);
+        }
+    }
+    
+    private async Task CheckClientStatusAsync()
+    {
+        var stats = await LcuService.GetAsync<CurrentRankedStatsDto>("/lol-ranked/v1/current-ranked-stats");
+        isClientRunning = stats != null;
+        if (isClientRunning)
+        {
+            rankedEntry = stats.HighestRankedEntry;
+        }
+    }
+
+    private async Task FetchRankedData()
+    {
+        var stats = await LcuService.GetAsync<CurrentRankedStatsDto>("/lol-ranked/v1/current-ranked-stats");
+        if (stats != null)
+        {
+            isClientRunning = true;
+            rankedEntry = stats.HighestRankedEntry;
+        }
+        else
+        {
+            isClientRunning = false;
+            rankedEntry = null;
+        }
+    }
+}

--- a/Components/Pages/Dashboard.razor
+++ b/Components/Pages/Dashboard.razor
@@ -4,6 +4,7 @@
 @using RiotAccountManager.MAUI.Services.RiotClientService
 @inject AccountRepository Repository
 @inject IRiotClientService RiotClient
+@inject NavigationManager NavigationManager
 
 <h3>Dashboard</h3>
 
@@ -23,6 +24,7 @@
             <td>@acc.Nickname</td>
             <td>
                 <button @onclick="@(() => Login(acc))" class="btn btn-success">Login</button>
+                <button @onclick="@(() => ShowDetails(acc))" class="btn btn-info">Details</button>
             </td>
         </tr>
     }
@@ -40,5 +42,10 @@
     private async Task Login(Account account)
     {
         await RiotClient.AutoLogin(account);
+    }
+
+    private void ShowDetails(Account account)
+    {
+        NavigationManager.NavigateTo($"/accountdetails/{account.Username}");
     }
 }

--- a/Data/Models/CurrentRankedStatsDto.cs
+++ b/Data/Models/CurrentRankedStatsDto.cs
@@ -1,0 +1,13 @@
+﻿namespace RiotAccountManager.MAUI.Data.Models;
+
+public class CurrentRankedStatsDto
+{
+    public int CurrentSeasonSplitPoints { get; set; }
+    public List<string> EarnedRegaliaRewardIds { get; set; }
+    public string HighestCurrentSeasonReachedTierSR { get; set; }
+    public string HighestPreviousSeasonEndDivision { get; set; }
+    public string HighestPreviousSeasonEndTier { get; set; }
+    public RankedEntryDto HighestRankedEntry { get; set; }
+    public RankedEntryDto HighestRankedEntrySR { get; set; }
+    public int PreviousSeasonSplitPoints { get; set; }
+}

--- a/Data/Models/RankedEntryDto.cs
+++ b/Data/Models/RankedEntryDto.cs
@@ -1,0 +1,24 @@
+﻿namespace RiotAccountManager.MAUI.Data.Models;
+
+public class RankedEntryDto
+{
+    public string Division { get; set; }
+    public string HighestDivision { get; set; }
+    public string HighestTier { get; set; }
+    public bool IsProvisional { get; set; }
+    public int LeaguePoints { get; set; }
+    public int Losses { get; set; }
+    public string MiniSeriesProgress { get; set; }
+    public string PreviousSeasonEndDivision { get; set; }
+    public string PreviousSeasonEndTier { get; set; }
+    public string PreviousSeasonHighestDivision { get; set; }
+    public string PreviousSeasonHighestTier { get; set; }
+    public int ProvisionalGameThreshold { get; set; }
+    public int ProvisionalGamesRemaining { get; set; }
+    public string QueueType { get; set; }
+    public int RatedRating { get; set; }
+    public string RatedTier { get; set; }
+    public string Tier { get; set; }
+    public object Warnings { get; set; }
+    public int Wins { get; set; }
+}

--- a/Data/Models/SummonerDto.cs
+++ b/Data/Models/SummonerDto.cs
@@ -1,0 +1,9 @@
+﻿namespace RiotAccountManager.MAUI.Data.Models;
+
+public class SummonerDto
+{
+    public string SummonerName { get; set; }
+    public int Level { get; set; }
+    public string Rank { get; set; }
+    public string BlueEssence { get; set; }
+}


### PR DESCRIPTION
## Summary by Sourcery

This pull request introduces a new 'AccountDetails' page that displays detailed information about a selected account, including ranked data fetched from the League of Legends client. It also adds a button to navigate to this page from the dashboard.

New Features:
- Introduce an Account Details page to display detailed information about a selected account.
- Display ranked data on the Account Details page, including queue type, tier, division, league points, wins, and losses.
- Implement a mechanism to check the League of Legends client status and display a message if it's not running.